### PR TITLE
Fixes from tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Python application
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+
+    - name: Cache pip dependencies
+      id: cache-pip
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: pip install -r requirements.txt && pip install .[test]
+
+    - name: Run tests
+      run: pytest

--- a/pytdml/io/tdml_readers.py
+++ b/pytdml/io/tdml_readers.py
@@ -51,9 +51,11 @@ def read_from_json(file_path: str):
 def parse_json(json_dict):
     # Different kinds of training datasets are supported
     if json_dict["type"] == "TrainingDataset":
-        return TrainingDataset.from_dict(json_dict)
+        return TrainingDataset(**json_dict)
     elif json_dict["type"] == "EOTrainingDataset":
-        return EOTrainingDataset.from_dict(json_dict)
+        return EOTrainingDataset(**json_dict)
+    elif json_dict["type"] == "AI_EOTrainingDataset":
+        return EOTrainingDataset(**json_dict)
     else:
         raise ValueError("Unknown TDML type: {}".format(json_dict["type"]))
 

--- a/pytdml/type/basic_types.py
+++ b/pytdml/type/basic_types.py
@@ -89,11 +89,11 @@ class MD_Band(BaseCamelModel):
     peak_response: Optional[float]
     tone_gradation: Optional[int]
 
-    @root_validator(pre=True)
-    def check_dependent_required(cls, v):
-        bound_units = v.get("boundUnits")
-        bound_max = v.get("boundMax")
-        bound_min = v.get("boundMin")
+    @model_validator(mode="before")
+    def check_dependent_required(self):
+        bound_units = self.get("boundUnits")
+        bound_max = self.get("boundMax")
+        bound_min = self.get("boundMin")
 
         # check dependRequired in jsonschema
         if bound_units is not None and (bound_max is None or bound_min is None):
@@ -101,7 +101,7 @@ class MD_Band(BaseCamelModel):
                 "boundMax and boundMin are required when boundUnits is present"
             )
 
-        return v
+        return self
 
 
 class MD_Scope(BaseCamelModel):

--- a/pytdml/type/basic_types.py
+++ b/pytdml/type/basic_types.py
@@ -30,10 +30,9 @@
 #
 # ------------------------------------------------------------------------------
 
-from typing import List, Union, Optional, Dict, Literal
-from pydantic import BaseModel, Field, field_validator, root_validator, validator
+from typing import List, Union, Optional, Literal
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pytdml.type._utils import _validate_date, to_camel, _valid_methods, _validate_training_type
-from pytdml.type.extended_types import EOTask, EOTrainingData, PixelLabel, ObjectLabel, SceneLabel
 
 
 class BaseCamelModel(BaseModel):
@@ -453,7 +452,7 @@ class TrainingData(BaseCamelModel):
 
     type: Literal["AI_AbstractTrainingData"]
     id: str
-    labels: List[Union[Label, PixelLabel, ObjectLabel, SceneLabel]]
+    labels: List[Union[Label, "PixelLabel", "ObjectLabel", "SceneLabel"]]
 
     dataset_id: Optional[str]
     data_sources: Optional[List[CI_Citation]] = None
@@ -517,9 +516,9 @@ class AI_TDChangeset(BaseCamelModel):
     dataset_id: Optional[str]
     version: Optional[str]
     created_time: Optional[str]
-    add: Optional[List[Union[TrainingData, EOTrainingData]]]
-    modify: Optional[List[Union[TrainingData, EOTrainingData]]]
-    delete: Optional[List[Union[TrainingData, EOTrainingData]]]
+    add: Optional[List[Union[TrainingData, "EOTrainingData"]]]
+    modify: Optional[List[Union[TrainingData, "EOTrainingData"]]]
+    delete: Optional[List[Union[TrainingData, "EOTrainingData"]]]
 
     @field_validator("created_time")
     def validate_created_time(cls, v):
@@ -535,8 +534,8 @@ class TrainingDataset(BaseCamelModel):
     name: str
     description: str
     license: str
-    tasks: List[Task, EOTask] = Field(min_items=1)
-    data: List[TrainingData, EOTrainingData] = Field(min_items=1)  # That one should be uri-format
+    tasks: List[Union[Task, "EOTask"]] = Field(min_items=1)
+    data: List[Union[TrainingData, "EOTrainingData"]] = Field(min_items=1)  # That one should be uri-format
     type: Literal["AI_AbstractTrainingDataset"]
 
     amount_Of_TrainingData: Optional[int]

--- a/pytdml/type/extended_types.py
+++ b/pytdml/type/extended_types.py
@@ -113,7 +113,7 @@ class EOTrainingDataset(TrainingDataset):
     type: Literal["AI_EOTrainingDataset"]
     # For Convinience, we allow the user to specify the bands by name
 
-    bands: Optional[List[MD_Band]] = []
+    bands: Optional[List[Union[str, MD_Band]]] = []
     extent: Optional[Extent]
     imageSize: Optional[str] = ""
     tasks: List[EOTask] = Field(min_items=1)
@@ -127,4 +127,3 @@ if __name__ == "__main__":
 
     td = EOTrainingDataset(**data).dict(by_alias=True,exclude_none=True)
     print(td['data'])
-    Union[str, MD_Band]

--- a/pytdml/utils.py
+++ b/pytdml/utils.py
@@ -193,17 +193,17 @@ def get_mapping_(file):
     return None
 
 
-try:
-    pixel_map = get_mapping_("pixel")
-    name_map = get_mapping_("name")
-except e:
-    print("S3 server running wrong...")
+pixel_map = None
+name_map = None
 
 
 def label_class_list_(pixel_list):
     """
         transform label pixel list to label class list
     """
+    global pixel_map
+    if pixel_map is None:
+        pixel_map = get_mapping_("pixel")
     if len(pixel_list) > 0:
 
         label_class_list = [item["type"] for item in pixel_map if int(item["pngValue"]) in pixel_list]
@@ -259,7 +259,9 @@ def regenerate_png_label_(label_array: Image, cls_list):
     """
     Zero the pixels in the png label that are not in the category offered by the user
     """
-    # pixel_map = get_mapping_("pixel")
+    global pixel_map
+    if pixel_map is None:
+        pixel_map = get_mapping_("pixel")
 
     pixel_list = [int(item["pngValue"]) for item in pixel_map if item["type"] in cls_list]
 
@@ -284,8 +286,10 @@ def dataset_name_map_(obs_name):
     """
     convert obs path name to dataset name
     """
-    # name_map = get_mapping_("name")
-    # print(type(name_map))
+    global name_map
+
+    if name_map is None:
+        name_map = get_mapping_("name")
     return [d for d in name_map if d["obs_path"] == obs_name][0]["name"]
 
 


### PR DESCRIPTION
# Fixes coming from running the tests

## Cyclic import

To solve this issue, I made the less intrusive approach possible: use forward references for the extended types referenced inside the basic types file. This does not solve the underlying architectural problem though.

## Contacting services on import

This solves the issue that caused the library to hang out when using anything inside the utils file. The proposed solution is trying to unblock some workflows, a better solution would be to make separated set of dependencies for the advanced use of the library, avoiding these external contacts and avoiding to install huge libraries like torch for the core usage.

## Partial pydantic upgrade

In the requirements pydantic v2 was used, but some parts of the code were still in v1. The ones fixed in this PR are only the ones that were failing when running the tests.
